### PR TITLE
Add non-EventHandler plugins handling for `PluginsBearer.emit` method

### DIFF
--- a/src/pluginable_core/event.py
+++ b/src/pluginable_core/event.py
@@ -116,6 +116,9 @@ class Event(BaseModel, t.Generic[_EventHandlerT]):
 
     def emit_to(self, handler: _EventHandlerT) -> None:
         # TODO: Should it raise an exception, warning or just ignore it?
+        #   I think it should ignore event when handler is not compatible with
+        #   it. If some event will be emit to non-compatible event handler, it
+        #   won't handle it.
         # if (self.get_handler_method(handler)) is None:
         #     raise EventNotSupported(
         #         f"{self.__class__} event is not supported by: {handler}. "

--- a/src/pluginable_core/plugin.py
+++ b/src/pluginable_core/plugin.py
@@ -4,9 +4,7 @@ from abc import ABC, abstractmethod
 
 from pluginable_core import exc
 from pluginable_core.context import AbstractAsyncContextStackManager
-
-if t.TYPE_CHECKING:
-    from pluginable_core.event import Event
+from pluginable_core.event import Event, EventHandler
 
 
 _PluginsBearerT = t.TypeVar(
@@ -75,10 +73,11 @@ class PluginsBearer(t.Generic[_PluginT], AbstractAsyncContextStackManager):
         :param event:
         :return:
         """
-        # TODO: This assumes all plugins are event handlers - is it true?
-        #   Maybe this method shouldn't be implemented here?
         for plugin in self.plugins:
-            event.emit_to(plugin)
+            # TODO: Is this legit solution for handling if plugin have proper
+            #  interface for handling events?
+            if isinstance(plugin, EventHandler):
+                event.emit_to(plugin)
 
 
 class Plugin(


### PR DESCRIPTION
# Changelog

## Fixes
- `PluginsBearer.emit` method should now properly handle emitting events to plugins which are not `EventHandler`s.